### PR TITLE
Added hint on branch protection to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+test change

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
-test change
+# HippoCampus Common
+The `master` branch is protected. To merge changes, create a pull request. An approving review is required to merge the pull request.


### PR DESCRIPTION
I modified the repo's settings so that no direct pushes to `master` are allowed anymore. So I added a hint in the README on how to get changes merged into the `master` branch.