### PR TITLE
Permit launch of tf_publisher.launch without setting "vehicle_type"

### DIFF
--- a/config/bluerov_sensor_poses_default.yaml
+++ b/config/bluerov_sensor_poses_default.yaml
@@ -3,19 +3,19 @@
 
 # Frame convention following ROS/Gazebo
 front_camera:
-  x: 0.15
+  x: 0.3
   y: 0.0
-  z: 0.07
+  z: 0.05
   roll: 0.0
   pitch: 0.0
   yaw: 0.0
-
+  
 vertical_camera:
-  x: 0.15
+  x: 0.3
   y: 0.0
-  z: -0.08
+  z: -0.05
   roll: 0.0
-  pitch: 1.57
+  pitch: 1.5708
   yaw: 0.0
   
 # Frame convention following ROS/Gazebo

--- a/launch/tf_publisher.launch
+++ b/launch/tf_publisher.launch
@@ -5,5 +5,7 @@
 
     <node pkg="hippocampus_common" type="tf_publisher_node" name="tf_publisher_node" output="screen">
         <rosparam command="load" file="$(find hippocampus_common)/config/$(arg sensor_pose_config_file)" />
+        <param name="vehicle_name" value="$(arg vehicle_name)"/>
+        <param name="vehicle_type" value="$(arg vehicle_type)"/>
     </node>
 </launch>

--- a/launch/tf_publisher.launch
+++ b/launch/tf_publisher.launch
@@ -1,11 +1,11 @@
 <launch>
-    <arg name="vehicle_name" doc="Something like 'uuv04' or 'bluerov.'" />
-    <arg name="vehicle_type" doc="Either 'hippocampus' or 'bluerov'."/>
+    <arg name="vehicle_name" default="None" doc="Something like 'uuv04' or 'bluerov.'" />
+    <arg name="vehicle_type" default="None" doc="Either 'hippocampus' or 'bluerov'."/>
     <arg name="sensor_pose_config_file" default="$(arg vehicle_type)_sensor_poses_default.yaml"/>
 
     <node pkg="hippocampus_common" type="tf_publisher_node" name="tf_publisher_node" output="screen">
-        <rosparam command="load" file="$(find hippocampus_common)/config/$(arg sensor_pose_config_file)" />
-        <param name="vehicle_name" value="$(arg vehicle_name)"/>
-        <param name="vehicle_type" value="$(arg vehicle_type)"/>
+        <rosparam unless="$(eval 'None' in arg('sensor_pose_config_file'))" command="load" file="$(find hippocampus_common)/config/$(arg sensor_pose_config_file)" />
+        <param unless="$(eval arg('vehicle_name')=='None')" name="vehicle_name" value="$(arg vehicle_name)"/>
+        <param unless="$(eval arg('vehicle_type')=='None')" name="vehicle_type" value="$(arg vehicle_type)"/>
     </node>
 </launch>

--- a/nodes/tf_publisher_node
+++ b/nodes/tf_publisher_node
@@ -50,9 +50,9 @@ class TfPublisherNode(Node):
 
         self.static_broadcaster = tf2_ros.StaticTransformBroadcaster()
         self.tf_broadcaster = tf2_ros.TransformBroadcaster()
-        vehicle_name = self.get_param("vehicle_name", "uuv00")
+        vehicle_name = self.get_param("~vehicle_name", "bluerov")
         self.tf_helper = TfHelper(vehicle_name)
-        self.vehicle_type = self.get_param("vehicle_type")
+        self.vehicle_type = self.get_param("~vehicle_type", "bluerov")
 
         # HippoCampus only has one camera
         if self.vehicle_type == "hippocampus":

--- a/nodes/tf_publisher_node
+++ b/nodes/tf_publisher_node
@@ -32,6 +32,9 @@ publishes the transformed data as PoseStamped/TwistStamped:
 """
 
 import rospy
+import rospkg
+import os
+import yaml
 from geometry_msgs.msg import PoseStamped, TwistStamped, Quaternion, \
     TransformStamped, Vector3
 from nav_msgs.msg import Odometry
@@ -42,6 +45,8 @@ import tf2_geometry_msgs
 from hippocampus_common.node import Node
 from hippocampus_common.tf_helper import TfHelper
 import math
+
+PACKAGE = "hippocampus_common"
 
 
 class TfPublisherNode(Node):
@@ -180,6 +185,22 @@ class TfPublisherNode(Node):
         # publish the message of the transformed twist
         self.ground_truth_twist_pub.publish(twist)
 
+    def _get_sensor_config(self, param_names):
+        rospy.logwarn("No Sensor Pose given! Using default values")
+        param_list = [0.0]*len(param_names)
+        config_file_name = self.vehicle_type+"_sensor_poses_default.yaml"
+        package_path = rospkg.RosPack().get_path(PACKAGE)
+        config_file_path = os.path.join(package_path, "config", config_file_name)
+        with open(config_file_path, 'r') as stream:
+            data = yaml.safe_load(stream)
+        for i, param_name in enumerate(param_names):
+            split_param_name = param_name.split('/')
+            param = data[split_param_name[0]]
+            for split in split_param_name[1:]:
+                param = param[split]
+            param_list[i] = param
+        return param_list
+
     def get_vertical_camera_link_transform(self):
         if not self._vertical_camera_link_tf:
             self._vertical_camera_link_tf = \
@@ -187,13 +208,22 @@ class TfPublisherNode(Node):
         return self._vertical_camera_link_tf
 
     def _get_vertical_camera_link_transform(self):
-        # read the pose from the parameter server
-        pos_x = Node.get_param("~vertical_camera/x", 0.0)
-        pos_y = Node.get_param("~vertical_camera/y", 0.0)
-        pos_z = Node.get_param("~vertical_camera/z", 0.0)
-        roll = Node.get_param("~vertical_camera/roll", 0.0)
-        pitch = Node.get_param("~vertical_camera/pitch", 0.0)
-        yaw = Node.get_param("~vertical_camera/yaw", 0.0)
+        try:
+            # read the pose from the parameter server
+            pos_x = Node.get_param("~vertical_camera/x")
+            pos_y = Node.get_param("~vertical_camera/y")
+            pos_z = Node.get_param("~vertical_camera/z")
+            roll = Node.get_param("~vertical_camera/roll")
+            pitch = Node.get_param("~vertical_camera/pitch")
+            yaw = Node.get_param("~vertical_camera/yaw")
+        except UnboundLocalError:
+            pos_x, pos_y, pos_z, roll, pitch, yaw = \
+                self._get_sensor_config(['vertical_camera/x',
+                                         'vertical_camera/y',
+                                         'vertical_camera/z',
+                                         'vertical_camera/roll',
+                                         'vertical_camera/pitch',
+                                         'vertical_camera/yaw'])
 
         # create a transform message that will be returned by this function
         transform = TransformStamped()
@@ -239,13 +269,22 @@ class TfPublisherNode(Node):
         return self._front_camera_link_tf
 
     def _get_front_camera_link_transform(self):
-        # read the pose from the parameter server
-        pos_x = Node.get_param("~front_camera/x", 0.0)
-        pos_y = Node.get_param("~front_camera/y", 0.0)
-        pos_z = Node.get_param("~front_camera/z", 0.0)
-        roll = Node.get_param("~front_camera/roll", 0.0)
-        pitch = Node.get_param("~front_camera/pitch", 0.0)
-        yaw = Node.get_param("~front_camera/yaw", 0.0)
+        try:
+            # read the pose from the parameter server
+            pos_x = Node.get_param("~front_camera/x")
+            pos_y = Node.get_param("~front_camera/y")
+            pos_z = Node.get_param("~front_camera/z")
+            roll = Node.get_param("~front_camera/roll")
+            pitch = Node.get_param("~front_camera/pitch")
+            yaw = Node.get_param("~front_camera/yaw")
+        except UnboundLocalError:
+            pos_x, pos_y, pos_z, roll, pitch, yaw = \
+                self._get_sensor_config(['front_camera/x',
+                                         'front_camera/y',
+                                         'front_camera/z',
+                                         'front_camera/roll',
+                                         'front_camera/pitch',
+                                         'front_camera/yaw'])
 
         # create a transform message that will be returned by this function
         transform = TransformStamped()
@@ -285,10 +324,15 @@ class TfPublisherNode(Node):
         return self._front_camera_frame_tf
 
     def _get_barometer_transform(self):
-
-        pos_x = Node.get_param("~barometer/x", 0.0)
-        pos_y = Node.get_param("~barometer/y", 0.0)
-        pos_z = Node.get_param("~barometer/z", 0.0)
+        try:
+            pos_x = Node.get_param("~barometer/x")
+            pos_y = Node.get_param("~barometer/y")
+            pos_z = Node.get_param("~barometer/z")
+        except UnboundLocalError:
+            pos_x, pos_y, pos_z = \
+                self._get_sensor_config(['barometer/x',
+                                         'barometer/y',
+                                         'barometer/z'])
 
         transform = TransformStamped()
         transform.header.stamp = rospy.Time.now()

--- a/src/hippocampus_common/tf_helper.py
+++ b/src/hippocampus_common/tf_helper.py
@@ -110,8 +110,7 @@ class TfHelper(object):
 
     def get_vertical_camera_frame_id(self):
         if not self._vertical_camera_frame_id:
-            self._vertical_camera_frame_id = self._get_vertical_camera_frame_id(
-            )
+            self._vertical_camera_frame_id = self._get_vertical_camera_frame_id()
         return self._vertical_camera_frame_id
 
     def get_barometer_link_id(self):


### PR DESCRIPTION
In tf_publisher.launch:
Parameters "vehicle_name" and "vehicle_type" are passed to tf_publisher_node if arguments were set. Parameters from "sensor_pose_config_file" are only loaded if "vehicle_type" or "sensor_pose_config_file" was set.

In tf_publisher_node:
If parameters from "sensor_pose_config_file" were not loaded, they are read from the yaml-file of the (default) vehicle type.